### PR TITLE
2 fixes to state in cancelBeforeInitiation() & settle()

### DIFF
--- a/src/BitSignal.sol
+++ b/src/BitSignal.sol
@@ -79,12 +79,12 @@ contract BitSignal {
         require(!betInitiated, "bet already started");
 
         if (usdcDeposited) {
-            USDC.transfer(balajis, USDC.balanceOf(address(this)));
             usdcDeposited = false;
+            USDC.transfer(balajis, USDC.balanceOf(address(this)));
         }
         if (wbtcDeposited) {
-            WBTC.transfer(counterparty, WBTC.balanceOf(address(this)));
             wbtcDeposited = false;
+            WBTC.transfer(counterparty, WBTC.balanceOf(address(this)));
         }
     }
 

--- a/src/BitSignal.sol
+++ b/src/BitSignal.sol
@@ -90,8 +90,11 @@ contract BitSignal {
 
     /// @notice Once 90 days have passed, query Chainlink BTC/USD price feed to determine the winner and send them both collaterals.
     function settle() external {
-        require(betInitiated && block.timestamp >= startTimestamp + BET_LENGTH, "bet not finished");
+        require(betInitiated, "bet not initiated");
+        require(block.timestamp >= startTimestamp + BET_LENGTH, "bet not finished");
 
+        betInitiated = false;
+        
         uint256 wbtcPrice = chainlinkPrice() / 10**priceFeed.decimals();
 
         address winner;


### PR DESCRIPTION
In cancelBeforeInitiation(), set bool flags = false before initiating transfers; best practice to prevent potential re-entrancy attacks

In settle(), set betInitiated = false so that settle() can't be called multiple times for a bet which has already been settled.